### PR TITLE
added equality operator overload

### DIFF
--- a/filesystem/path.h
+++ b/filesystem/path.h
@@ -302,6 +302,10 @@ public:
     path &operator=(const std::wstring &str) { set(str); return *this; }
 #endif
 
+    bool operator==(const path &left) const {
+        return left.m_path == this->m_path;
+    }
+
 protected:
     static std::vector<std::string> tokenize(const std::string &string, const std::string &delim) {
         std::string::size_type lastPos = 0, pos = string.find_first_of(delim, lastPos);

--- a/path_demo.cpp
+++ b/path_demo.cpp
@@ -21,6 +21,8 @@ int main(int argc, char **argv) {
     cout << (path1/path2).parent_path().parent_path().parent_path() << endl;
     cout << (path1/path2).parent_path().parent_path().parent_path().parent_path() << endl;
     cout << path().parent_path() << endl;
+    cout << "some/path.ext:operator==() = " << (path("some/path.ext") == path("some/path.ext")) << endl;
+    cout << "some/path.ext:operator==() (unequal) = " << (path("some/path.ext") == path("another/path.ext")) << endl;
 
     cout << "nonexistant:exists = " << path("nonexistant").exists() << endl;
     cout << "nonexistant:is_file = " << path("nonexistant").is_file() << endl;


### PR DESCRIPTION
Added an overload for `operator==()` because coercing to string to check for equality is annoying and unnecessary.