### PR TITLE
Fixes on cygwin and win32

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,6 @@ cmake_minimum_required(VERSION 2.8)
 project(path)
 if (CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR CMAKE_CXX_COMPILER_ID MATCHES "GNU")
   # Enable C++11 mode on GCC / Clang
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -U__STRICT_ANSI__")
 endif()
 add_executable(path_demo path_demo.cpp filesystem/path.h filesystem/resolver.h)

--- a/filesystem/path.h
+++ b/filesystem/path.h
@@ -18,6 +18,7 @@
 #include <cstdlib>
 #include <cerrno>
 #include <cstring>
+#include <climits>
 
 #if defined(_WIN32)
 # include <windows.h>
@@ -56,9 +57,11 @@ public:
     path(const path &path)
         : m_type(path.m_type), m_path(path.m_path), m_absolute(path.m_absolute) {}
 
+#if __cplusplus >= 201103L
     path(path &&path)
         : m_type(path.m_type), m_path(std::move(path.m_path)),
           m_absolute(path.m_absolute) {}
+#endif
 
     path(const char *string) { set(string); }
 
@@ -219,6 +222,7 @@ public:
         return *this;
     }
 
+#if __cplusplus >= 201103L
     path &operator=(path &&path) {
         if (this != &path) {
             m_type = path.m_type;
@@ -227,6 +231,7 @@ public:
         }
         return *this;
     }
+#endif
 
     friend std::ostream &operator<<(std::ostream &os, const path &path) {
         os << path.str();

--- a/filesystem/path.h
+++ b/filesystem/path.h
@@ -152,10 +152,21 @@ public:
     }
 
     std::string filename() const {
-        if (empty())
-            return m_ends_slash ? std::string(1, slash()) : "";
-        const std::string &last = m_ends_slash ? "." : m_path[m_path.size() - 1];
-        return last;
+        if (empty()) {
+            std::ostringstream oss;
+         
+            if (m_type == windows_path && m_volume != 0 && !m_absolute)
+                oss << m_volume << ':';
+            
+            if (m_ends_slash)
+                oss << slash();
+            
+            return oss.str();
+        }
+        else {
+            const std::string &last = m_ends_slash ? "." : m_path[m_path.size() - 1];
+            return last;
+        } 
     }
 
     path parent_path() const {

--- a/filesystem/path.h
+++ b/filesystem/path.h
@@ -145,10 +145,15 @@ public:
 
     std::string extension() const {
         const std::string &name = filename();
+        
+        if (name.empty() || name.front() == '.')
+            return "";
+
         size_t pos = name.find_last_of(".");
         if (pos == std::string::npos)
             return "";
-        return name.substr(pos+1);
+
+        return name.substr(pos);    // include "." in extension
     }
 
     std::string filename() const {

--- a/filesystem/path.h
+++ b/filesystem/path.h
@@ -154,7 +154,7 @@ public:
     std::string filename() const {
         if (empty())
             return m_ends_slash ? std::string(1, slash()) : "";
-        const std::string &last = m_path[m_path.size()-1];
+        const std::string &last = m_ends_slash ? "." : m_path[m_path.size() - 1];
         return last;
     }
 
@@ -162,11 +162,11 @@ public:
         path result;
         result.m_absolute = m_absolute;
         result.m_starts_slash = m_starts_slash;
-        result.m_ends_slash = m_ends_slash;
+        result.m_ends_slash = false;
         result.m_volume = m_volume;
 
         if (!m_path.empty()) {
-            size_t until = m_path.size() - 1;
+            size_t until = m_ends_slash ? m_path.size() : m_path.size() - 1;
             for (size_t i = 0; i < until; ++i)
                 result.m_path.push_back(m_path[i]);
         }

--- a/filesystem/path.h
+++ b/filesystem/path.h
@@ -159,7 +159,7 @@ public:
     path parent_path() const {
         path result;
         result.m_absolute = m_absolute;
-		result.m_volume = m_volume;
+        result.m_volume = m_volume;
 
         if (m_path.empty()) {
             if (!m_absolute)
@@ -188,18 +188,18 @@ public:
 
     std::string str(path_type type = native_path) const {
         std::ostringstream oss;
-		char slash = m_type == posix_path ? '/' : '\\';
-		
-		if (m_type == windows_path && m_volume != 0)
-			oss << m_volume << ':';
+        char slash = m_type == posix_path ? '/' : '\\';
+        
+        if (m_type == windows_path && m_volume != 0)
+            oss << m_volume << ':';
 
         if (m_absolute)
             oss << slash;
 
-		for (size_t i = 0; i < m_path.size(); ++i) {
+        for (size_t i = 0; i < m_path.size(); ++i) {
             oss << m_path[i];
             if (i+1 < m_path.size()) {
-				oss << slash;
+                oss << slash;
             }
         }
 
@@ -208,20 +208,20 @@ public:
 
     void set(const std::string &str, path_type type = native_path) {
         m_type = type;
-		m_volume = 0;
+        m_volume = 0;
         if (type == windows_path) {
-			if (str.size() >= 2 && std::isalpha(str[0]) && str[1] == ':') {
-				m_volume = str[0];
-				m_path = tokenize(str.substr(2), "/\\");
-				m_absolute = (str.size() >= 3 && (str[2] == '/' || str[2] == '\\'));
-			}
-			else {
-				m_path = tokenize(str, "/\\");
-				m_absolute = false;
-			}
-		}
-		else {
-			m_path = tokenize(str, "/");
+            if (str.size() >= 2 && std::isalpha(str[0]) && str[1] == ':') {
+                m_volume = str[0];
+                m_path = tokenize(str.substr(2), "/\\");
+                m_absolute = (str.size() >= 3 && (str[2] == '/' || str[2] == '\\'));
+            }
+            else {
+                m_path = tokenize(str, "/\\");
+                m_absolute = false;
+            }
+        }
+        else {
+            m_path = tokenize(str, "/");
             m_absolute = !str.empty() && str[0] == '/';
         }
     }
@@ -230,7 +230,7 @@ public:
         m_type = path.m_type;
         m_path = path.m_path;
         m_absolute = path.m_absolute;
-		m_volume = path.m_volume;
+        m_volume = path.m_volume;
         return *this;
     }
 
@@ -240,8 +240,8 @@ public:
             m_type = path.m_type;
             m_path = std::move(path.m_path);
             m_absolute = path.m_absolute;
-			m_volume = path.m_volume;
-		}
+            m_volume = path.m_volume;
+        }
         return *this;
     }
 #endif
@@ -344,7 +344,7 @@ protected:
     path_type m_type;
     std::vector<std::string> m_path;
     bool m_absolute;
-	char m_volume;			// volume letter on windows_path
+    char m_volume;          // volume letter on windows_path
 };
 
 inline bool create_directory(const path& p) {

--- a/filesystem/path.h
+++ b/filesystem/path.h
@@ -161,10 +161,7 @@ public:
         result.m_absolute = m_absolute;
         result.m_volume = m_volume;
 
-        if (m_path.empty()) {
-            if (!m_absolute)
-                result.m_path.push_back("..");
-        } else {
+        if (!m_path.empty()) {
             size_t until = m_path.size() - 1;
             for (size_t i = 0; i < until; ++i)
                 result.m_path.push_back(m_path[i]);

--- a/filesystem/path.h
+++ b/filesystem/path.h
@@ -328,13 +328,15 @@ protected:
         std::string::size_type lastPos = 0, pos = string.find_first_of(delim, lastPos);
         std::vector<std::string> tokens;
 
-        while (lastPos != std::string::npos) {
-            if (pos != lastPos)
-                tokens.push_back(string.substr(lastPos, pos - lastPos));
-            lastPos = pos;
-            if (lastPos == std::string::npos || lastPos + 1 == string.length())
-                break;
-            pos = string.find_first_of(delim, ++lastPos);
+        if (!string.empty()) {
+            while (lastPos != std::string::npos) {
+                if (pos != lastPos)
+                    tokens.push_back(string.substr(lastPos, pos - lastPos));
+                lastPos = pos;
+                if (lastPos == std::string::npos || lastPos + 1 == string.length())
+                    break;
+                pos = string.find_first_of(delim, ++lastPos);
+            }
         }
 
         return tokens;

--- a/path_demo.cpp
+++ b/path_demo.cpp
@@ -5,44 +5,373 @@
 using namespace std;
 using namespace filesystem;
 
-int main(int argc, char **argv) {
+// TAP-compliant test
+int failed_nr = 0;
+int test_nr = 0;
+#define DIAG(out) cout << "# " << out << endl
+#define _OK(cond, has_diag, diag) \
+    if (cond) \
+        cout << "ok " << (++test_nr) << endl; \
+    else { \
+        failed_nr++; \
+        cout << "not ok " << (++test_nr) << endl; \
+        DIAG("  Failed test at " << __FILE__ << " line " << __LINE__ << "."); \
+        if (has_diag) DIAG(diag); \
+    }
+
+#define OK(cond)        _OK((cond),     0, "")
+#define NOK(cond)       _OK(!(cond),    0, "")
+#define IS(a, b)        _OK((a) == (b), 1, (a))
+#define ISNT(a, b)      _OK((a) != (b), 1, (a))
+
+#define DONE_TESTING() \
+    cout << "1.." << test_nr << endl; \
+    if (failed_nr == 0) { \
+        return 0; \
+    } else { \
+        DIAG("Looks like you failed " << failed_nr << " test" << \
+             (failed_nr > 1 ? "s" : "") << " of " << test_nr << "."); \
+        return 1; \
+    }
+
+// Platform specifics
 #if !defined(WIN32)
-    path path1("/dir 1/dir 2/");
+#define ROOT    "/"
+#define SEP     "/"
 #else
-    path path1("C:\\dir 1\\dir 2\\");
+#define ROOT    "C:\\"
+#define SEP     "\\"
 #endif
+
+int main(int argc, char **argv) {
+    path path1(ROOT "dir 1" SEP "dir 2" SEP);
     path path2("dir 3");
+    path p;
 
-    cout << path1.exists() << endl;
-    cout << path1 << endl;
-    cout << (path1/path2) << endl;
-    cout << (path1/path2).parent_path() << endl;
-    cout << (path1/path2).parent_path().parent_path() << endl;
-    cout << (path1/path2).parent_path().parent_path().parent_path() << endl;
-    cout << (path1/path2).parent_path().parent_path().parent_path().parent_path() << endl;
-    cout << path().parent_path() << endl;
-    cout << "some/path.ext:operator==() = " << (path("some/path.ext") == path("some/path.ext")) << endl;
-    cout << "some/path.ext:operator==() (unequal) = " << (path("some/path.ext") == path("another/path.ext")) << endl;
+    // string
+    NOK(path1.exists());
+    IS(path1, ROOT "dir 1" SEP "dir 2");
+    IS(path2, "dir 3");
 
-    cout << "nonexistant:exists = " << path("nonexistant").exists() << endl;
-    cout << "nonexistant:is_file = " << path("nonexistant").is_file() << endl;
-    cout << "nonexistant:is_directory = " << path("nonexistant").is_directory() << endl;
-    cout << "nonexistant:filename = " << path("nonexistant").filename() << endl;
-    cout << "nonexistant:extension = " << path("nonexistant").extension() << endl;
-    cout << "filesystem/path.h:exists = " << path("filesystem/path.h").exists() << endl;
-    cout << "filesystem/path.h:is_file = " << path("filesystem/path.h").is_file() << endl;
-    cout << "filesystem/path.h:is_directory = " << path("filesystem/path.h").is_directory() << endl;
-    cout << "filesystem/path.h:filename = " << path("filesystem/path.h").filename() << endl;
-    cout << "filesystem/path.h:extension = " << path("filesystem/path.h").extension() << endl;
-    cout << "filesystem/path.h:make_absolute = " << path("filesystem/path.h").make_absolute() << endl;
-    cout << "../filesystem:exists = " << path("../filesystem").exists() << endl;
-    cout << "../filesystem:is_file = " << path("../filesystem").is_file() << endl;
-    cout << "../filesystem:is_directory = " << path("../filesystem").is_directory() << endl;
-    cout << "../filesystem:extension = " << path("../filesystem").extension() << endl;
-    cout << "../filesystem:filename = " << path("../filesystem").filename() << endl;
-    cout << "../filesystem:make_absolute = " << path("../filesystem").make_absolute() << endl;
+    // concatenate
+    IS(path1/path2, ROOT "dir 1" SEP "dir 2" SEP "dir 3");
 
-    cout << "resolve(filesystem/path.h) = " << resolver().resolve("filesystem/path.h") << endl;
-    cout << "resolve(nonexistant) = " << resolver().resolve("nonexistant") << endl;
-    return 0;
+    // parent
+    IS((path1/path2).parent_path(), ROOT "dir 1" SEP "dir 2");
+    IS((path1/path2).parent_path().parent_path(), ROOT "dir 1");
+    IS((path1/path2).parent_path().parent_path().parent_path(), ROOT);
+    IS((path1/path2).parent_path().parent_path().parent_path().parent_path(), ROOT);
+    IS((path1/path2).parent_path().parent_path().parent_path().parent_path().parent_path(), ROOT);
+
+    // is_absolute
+    OK(path1.is_absolute());
+    NOK(path2.is_absolute());
+
+    // test conditions for str(), is_absolute(), parent_path(), filename() from boost::filesystem
+    p = path("");
+    IS(p.str(), "");
+    NOK(p.is_absolute());
+    IS(p.parent_path(), "");
+    IS(p.filename(), "");
+
+    p = path(".");
+    IS(p.str(), ".");
+    NOK(p.is_absolute());
+    IS(p.parent_path(), "");
+    IS(p.filename(), ".");
+
+    p = path("..");
+    IS(p.str(), "..");
+    NOK(p.is_absolute());
+    IS(p.parent_path(), "");
+    IS(p.filename(), "..");
+
+    p = path("foo");
+    IS(p.str(), "foo");
+    NOK(p.is_absolute());
+    IS(p.parent_path(), "");
+    IS(p.filename(), "foo");
+
+    p = path("/");
+    IS(p.str(), SEP);
+#if defined(WIN32)
+    NOK(p.is_absolute());
+#else
+    OK(p.is_absolute());
+#endif
+    IS(p.parent_path(), "");
+    IS(p.filename(), SEP);
+
+    p = path("/foo");
+    IS(p.str(), SEP "foo");
+#if defined(WIN32)
+    NOK(p.is_absolute());
+#else
+    OK(p.is_absolute());
+#endif
+    IS(p.parent_path(), SEP);
+    IS(p.filename(), "foo");
+
+    p = path("foo/");
+    IS(p.str(), "foo" SEP);
+    NOK(p.is_absolute());
+    IS(p.parent_path(), "foo");
+    IS(p.filename(), ".");
+
+    p = path("/foo/");
+    IS(p.str(), SEP "foo" SEP);
+#if defined(WIN32)
+    NOK(p.is_absolute());
+#else
+    OK(p.is_absolute());
+#endif
+    IS(p.parent_path(), SEP "foo");
+    IS(p.filename(), ".");
+
+    p = path("foo/bar");
+    IS(p.str(), "foo" SEP "bar");
+    NOK(p.is_absolute());
+    IS(p.parent_path(), "foo");
+    IS(p.filename(), "bar");
+
+    p = path("/foo/bar");
+    IS(p.str(), SEP "foo" SEP "bar");
+#if defined(WIN32)
+    NOK(p.is_absolute());
+#else
+    OK(p.is_absolute());
+#endif
+    IS(p.parent_path(), SEP "foo");
+    IS(p.filename(), "bar");
+
+    p = path("/.");
+    IS(p.str(), SEP ".");
+#if defined(WIN32)
+    NOK(p.is_absolute());
+#else
+    OK(p.is_absolute());
+#endif
+    IS(p.parent_path(), SEP);
+    IS(p.filename(), ".");
+
+    p = path("./");
+    IS(p.str(), "." SEP);
+    NOK(p.is_absolute());
+    IS(p.parent_path(), ".");
+    IS(p.filename(), ".");
+
+    p = path("/..");
+    IS(p.str(), SEP "..");
+#if defined(WIN32)
+    NOK(p.is_absolute());
+#else
+    OK(p.is_absolute());
+#endif
+    IS(p.parent_path(), SEP);
+    IS(p.filename(), "..");
+
+    p = path("../");
+    IS(p.str(), ".." SEP);
+    NOK(p.is_absolute());
+    IS(p.parent_path(), "..");
+    IS(p.filename(), ".");
+
+    p = path("foo/.");
+    IS(p.str(), "foo" SEP ".");
+    NOK(p.is_absolute());
+    IS(p.parent_path(), "foo");
+    IS(p.filename(), ".");
+
+    p = path("foo/..");
+    IS(p.str(), "foo" SEP "..");
+    NOK(p.is_absolute());
+    IS(p.parent_path(), "foo");
+    IS(p.filename(), "..");
+
+    p = path("foo/./");
+    IS(p.str(), "foo" SEP "." SEP);
+    NOK(p.is_absolute());
+    IS(p.parent_path(), "foo" SEP ".");
+    IS(p.filename(), ".");
+
+    p = path("foo/./bar");
+    IS(p.str(), "foo" SEP "." SEP "bar");
+    NOK(p.is_absolute());
+    IS(p.parent_path(), "foo" SEP ".");
+    IS(p.filename(), "bar");
+
+    p = path("foo/..");
+    IS(p.str(), "foo" SEP "..");
+    NOK(p.is_absolute());
+    IS(p.parent_path(), "foo");
+    IS(p.filename(), "..");
+
+    p = path("foo/../");
+    IS(p.str(), "foo" SEP ".." SEP);
+    NOK(p.is_absolute());
+    IS(p.parent_path(), "foo" SEP "..");
+    IS(p.filename(), ".");
+
+    p = path("foo/../bar");
+    IS(p.str(), "foo" SEP ".." SEP "bar");
+    NOK(p.is_absolute());
+    IS(p.parent_path(), "foo" SEP "..");
+    IS(p.filename(), "bar");
+
+#if defined(WIN32)
+    p = path("\\foo");
+    IS(p.str(), SEP "foo");
+    NOK(p.is_absolute());
+    IS(p.parent_path(), SEP);
+    IS(p.filename(), "foo");
+
+    p = path("c:");
+    IS(p.str(), "c:");
+    NOK(p.is_absolute());
+    IS(p.parent_path(), "");
+    IS(p.filename(), "c:");
+
+    p = path("c:/");
+    IS(p.str(), "c:" SEP);
+    OK(p.is_absolute());
+    IS(p.parent_path(), "c:");
+    IS(p.filename(), SEP);
+
+    p = path("c:foo");
+    IS(p.str(), "c:foo");
+    NOK(p.is_absolute());
+    IS(p.parent_path(), "c:");
+    IS(p.filename(), "foo");
+
+    p = path("c:/foo");
+    IS(p.str(), "c:" SEP "foo");
+    OK(p.is_absolute());
+    IS(p.parent_path(), "c:" SEP);
+    IS(p.filename(), "foo");
+
+    p = path("c:foo/");
+    IS(p.str(), "c:foo" SEP);
+    NOK(p.is_absolute());
+    IS(p.parent_path(), "c:foo");
+    IS(p.filename(), ".");
+
+    p = path("c:/foo/");
+    IS(p.str(), "c:" SEP "foo" SEP);
+    OK(p.is_absolute());
+    IS(p.parent_path(), "c:" SEP "foo");
+    IS(p.filename(), ".");
+
+    p = path("c:/foo/bar");
+    IS(p.str(), "c:" SEP "foo" SEP "bar");
+    OK(p.is_absolute());
+    IS(p.parent_path(), "c:" SEP "foo");
+    IS(p.filename(), "bar");
+
+    p = path("c:\\");
+    IS(p.str(), "c:" SEP);
+    OK(p.is_absolute());
+    IS(p.parent_path(), "c:");
+    IS(p.filename(), SEP);
+
+    p = path("c:\\foo");
+    IS(p.str(), "c:" SEP "foo");
+    OK(p.is_absolute());
+    IS(p.parent_path(), "c:" SEP);
+    IS(p.filename(), "foo");
+
+    p = path("c:foo\\");
+    IS(p.str(), "c:foo" SEP);
+    NOK(p.is_absolute());
+    IS(p.parent_path(), "c:foo");
+    IS(p.filename(), ".");
+
+    p = path("c:\\foo\\");
+    IS(p.str(), "c:" SEP "foo" SEP);
+    OK(p.is_absolute());
+    IS(p.parent_path(), "c:" SEP "foo");
+    IS(p.filename(), ".");
+
+    p = path("c:\\foo/");
+    IS(p.str(), "c:" SEP "foo" SEP);
+    OK(p.is_absolute());
+    IS(p.parent_path(), "c:" SEP "foo");
+    IS(p.filename(), ".");
+
+    p = path("c:/foo\\bar");
+    IS(p.str(), "c:" SEP "foo" SEP "bar");
+    OK(p.is_absolute());
+    IS(p.parent_path(), "c:" SEP "foo");
+    IS(p.filename(), "bar");
+#endif
+
+    // operator==()
+    OK( path("some/path.ext") == path("some/path.ext"));
+    NOK(path("some/path.ext") == path("other/path.ext"));
+
+    // operator!=()
+    OK( path("some/path.ext") != path("other/path.ext"));
+    NOK(path("some/path.ext") != path("some/path.ext"));
+
+    // exists, is_file, is_directory
+    NOK(path("nonexistant").exists());
+    NOK(path("nonexistant").is_file());
+    NOK(path("nonexistant").is_directory());
+
+    OK( path("../filesystem").exists());
+    NOK(path("../filesystem").is_file());
+    OK( path("../filesystem").is_directory());
+
+    OK( path("filesystem").exists());
+    NOK(path("filesystem").is_file());
+    OK( path("filesystem").is_directory());
+
+    OK( path("filesystem/path.h").exists());
+    OK( path("filesystem/path.h").is_file());
+    NOK(path("filesystem/path.h").is_directory());
+
+    // filename, extension
+    p = path(".");
+    IS(p.filename(), ".");
+    IS(p.extension(), "");
+
+    p = path("..");
+    IS(p.filename(), "..");
+    IS(p.extension(), "");
+
+    p = path(".exrc");
+    IS(p.filename(), ".exrc");
+    IS(p.extension(), "");
+
+    p = path("yy.tab.h");
+    IS(p.filename(), "yy.tab.h");
+    IS(p.extension(), ".h");
+
+    p = path("nonexistant");
+    IS(p.filename(), "nonexistant");
+    IS(p.extension(), "");
+
+    p = path("filesystem/path.h");
+    IS(p.filename(), "path.h");
+    IS(p.extension(), ".h");
+
+    p = path("../filesystem");
+    IS(p.filename(), "filesystem");
+    IS(p.extension(), "");
+
+    // make_absolute
+    p = path("filesystem/path.h");
+    NOK(p.is_absolute());
+    OK(p.make_absolute().is_absolute());
+    DIAG(p.make_absolute());
+
+    p = path("../filesystem");
+    NOK(p.is_absolute());
+    OK(p.make_absolute().is_absolute());
+    DIAG(p.make_absolute());
+
+    // resolve
+    IS(resolver().resolve("filesystem/path.h"), path("filesystem/path.h").make_absolute());
+    IS(resolver().resolve("nonexistant"), "nonexistant");
+
+    DONE_TESTING();
 }


### PR DESCRIPTION
In cygwin, gcc -std=c++11 hides the realpath() function. Need to undefine __STRICT_ANSI__ to compile.
Need to include <climits> to have PATH_MAX.
Need to protect rvalue reference with #if / #endif for c++98 compiles.