### PR TITLE
Fix to compile on cygwin and on C++98

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,6 @@ cmake_minimum_required(VERSION 2.8)
 project(path)
 if (CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR CMAKE_CXX_COMPILER_ID MATCHES "GNU")
   # Enable C++11 mode on GCC / Clang
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -U__STRICT_ANSI__")
 endif()
 add_executable(path_demo path_demo.cpp filesystem/path.h filesystem/resolver.h)

--- a/filesystem/path.h
+++ b/filesystem/path.h
@@ -19,6 +19,7 @@
 #include <cerrno>
 #include <cstring>
 #include <climits>
+#include <cstdio>
 
 #if defined(_WIN32)
 # include <windows.h>
@@ -57,9 +58,11 @@ public:
     path(const path &path)
         : m_type(path.m_type), m_path(path.m_path), m_absolute(path.m_absolute) {}
 
+#if __cplusplus >= 201103L
     path(path &&path)
         : m_type(path.m_type), m_path(std::move(path.m_path)),
           m_absolute(path.m_absolute) {}
+#endif
 
     path(const char *string) { set(string); }
 
@@ -220,6 +223,7 @@ public:
         return *this;
     }
 
+#if __cplusplus >= 201103L
     path &operator=(path &&path) {
         if (this != &path) {
             m_type = path.m_type;
@@ -228,6 +232,7 @@ public:
         }
         return *this;
     }
+#endif
 
     friend std::ostream &operator<<(std::ostream &os, const path &path) {
         os << path.str();

--- a/filesystem/path.h
+++ b/filesystem/path.h
@@ -18,6 +18,7 @@
 #include <cstdlib>
 #include <cerrno>
 #include <cstring>
+#include <climits>
 
 #if defined(_WIN32)
 # include <windows.h>


### PR DESCRIPTION
Commit 0740d4e is required to compile the module with gcc 5.4.0 on cygwin 2.6.0.
Commit 10cee35 is required to be able to integrate filesystem/path.h in a project still using C++98