### PR TITLE
ADD Xtensa include macro to support ESP32 plattform

### DIFF
--- a/filesystem/path.h
+++ b/filesystem/path.h
@@ -32,6 +32,10 @@
 # include <linux/limits.h>
 #endif
 
+#if defined(__XTENSA__)
+# include <limits.h>
+#endif
+
 NAMESPACE_BEGIN(filesystem)
 
 /**


### PR DESCRIPTION
I added the corresponding include marco to support the ESP32 platform.