### PR TITLE
ADD string cast operator to path class

### DIFF
--- a/filesystem/path.h
+++ b/filesystem/path.h
@@ -216,6 +216,10 @@ public:
         return oss.str();
     }
 
+    inline operator std::string(){
+        return this->str();
+    }
+
     void set(const std::string &str, path_type type = native_path) {
         m_type = type;
         if (type == windows_path) {


### PR DESCRIPTION
I added the cast operator for `std::string`. It just invokes `path::str()`. It enables following usage:
```
path root{"/tmp"};
path file{"test.json"};

std::ifstream test {root / file};
```