### PR TITLE
Add several methods that are not in this repo but in STL 

### DIFF
--- a/filesystem/path.h
+++ b/filesystem/path.h
@@ -225,6 +225,10 @@ public:
         return oss.str();
     }
 
+    std::string string() const {
+        return str();
+    }
+
     void set(const std::string &str, path_type type = native_path) {
         m_type = type;
         if (type == windows_path) {
@@ -429,6 +433,14 @@ inline bool create_directories(const path& p) {
     }
     return false;
 #endif
+}
+
+inline bool exists(const path& p) {
+    return p.exists();
+}
+
+inline bool is_directory(const path& p) {
+    return p.is_directory();
 }
 
 NAMESPACE_END(filesystem)

--- a/path_demo.cpp
+++ b/path_demo.cpp
@@ -25,17 +25,20 @@ int main(int argc, char **argv) {
     cout << "some/path.ext:operator==() (unequal) = " << (path("some/path.ext") == path("another/path.ext")) << endl;
 
     cout << "nonexistant:exists = " << path("nonexistant").exists() << endl;
+    cout << "nonexistant:exists = " << exists(path("nonexistant")) << endl;
     cout << "nonexistant:is_file = " << path("nonexistant").is_file() << endl;
     cout << "nonexistant:is_directory = " << path("nonexistant").is_directory() << endl;
     cout << "nonexistant:filename = " << path("nonexistant").filename() << endl;
     cout << "nonexistant:extension = " << path("nonexistant").extension() << endl;
     cout << "filesystem/path.h:exists = " << path("filesystem/path.h").exists() << endl;
+    cout << "filesystem/path.h:exists = " << exists(path("filesystem/path.h")) << endl;
     cout << "filesystem/path.h:is_file = " << path("filesystem/path.h").is_file() << endl;
     cout << "filesystem/path.h:is_directory = " << path("filesystem/path.h").is_directory() << endl;
     cout << "filesystem/path.h:filename = " << path("filesystem/path.h").filename() << endl;
     cout << "filesystem/path.h:extension = " << path("filesystem/path.h").extension() << endl;
     cout << "filesystem/path.h:make_absolute = " << path("filesystem/path.h").make_absolute() << endl;
     cout << "../filesystem:exists = " << path("../filesystem").exists() << endl;
+    cout << "../filesystem:exists = " << exists(path("../filesystem")) << endl;
     cout << "../filesystem:is_file = " << path("../filesystem").is_file() << endl;
     cout << "../filesystem:is_directory = " << path("../filesystem").is_directory() << endl;
     cout << "../filesystem:extension = " << path("../filesystem").extension() << endl;


### PR DESCRIPTION
This PR introduces several methods that are not defined in this repo but defined in STL.

* `exists()` is defined as a method in `filesystem` namespace
  https://en.cppreference.com/w/cpp/filesystem/exists
* `is_directory()` is defined as a method in `filesystem` namespace
  https://en.cppreference.com/w/cpp/filesystem/is_directory
* `string()` is defined as a member of `path` object instead of `str()`
  https://en.cppreference.com/w/cpp/filesystem/path/string

For the backward compatibility, the methods, which are originally defined in this repo, are kept unchanged.